### PR TITLE
Reimplement __richcmp__ for all python types, __eq__ is ignored by PyO3

### DIFF
--- a/finance_enums/tests/test_currency.py
+++ b/finance_enums/tests/test_currency.py
@@ -3,6 +3,11 @@ from finance_enums import Currency
 
 class TestCurrency:
     def test_currency_basic(self):
-        assert len(Currency.members()) == 180
+        assert len(Currency.members()) == 183
         assert str(Currency.USD) == "USD"
         assert Currency.USD.name == "United States dollar"
+    
+    def test_noniso_currency_pennies(self):
+        assert Currency("EUr") == Currency.EUX
+        assert Currency("GBp") == Currency.GBX
+        assert Currency("USd") == Currency.USX

--- a/helpers/iso10383_generated.rs
+++ b/helpers/iso10383_generated.rs
@@ -2,7 +2,7 @@
 use super::CountryCode;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
 #[strum(serialize_all = "PascalCase")]
 pub enum MIC {
 	DRSP,

--- a/helpers/process_mics.py
+++ b/helpers/process_mics.py
@@ -32,7 +32,7 @@ to_writeout = """
 use super::CountryCode;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
 #[strum(serialize_all = "PascalCase")]
 pub enum MIC {
 """

--- a/rust/src/country/iso3166.rs
+++ b/rust/src/country/iso3166.rs
@@ -257,7 +257,9 @@ pub enum CountryCode {
     ZW,
 }
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "UPPERCASE")]
 pub enum CountryCode3 {
     AFG,

--- a/rust/src/currency/iso4217.rs
+++ b/rust/src/currency/iso4217.rs
@@ -2,7 +2,9 @@
 use crate::CountryCode;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "UPPERCASE")]
 pub enum Currency {
     AED,
@@ -53,9 +55,11 @@ pub enum Currency {
     ERN,
     ETB,
     EUR,
+    EUX, // NOTE: non ISO 4217
     FJD,
     FKP,
     GBP,
+    GBX, // NOTE: non ISO 4217
     GEL,
     GHS,
     GIP,
@@ -154,6 +158,7 @@ pub enum Currency {
     UAH,
     UGX,
     USD,
+    USX, // NOTE: non ISO 4217
     USN,
     UYI,
     UYU,
@@ -238,9 +243,11 @@ impl Currency {
             Currency::ERN => "Eritrean nakfa",
             Currency::ETB => "Ethiopian birr",
             Currency::EUR => "Euro",
+            Currency::EUX => "Euro (cents)",
             Currency::FJD => "Fiji dollar",
             Currency::FKP => "Falkland Islands pound",
             Currency::GBP => "Pound sterling",
+            Currency::GBX => "Penny sterling",
             Currency::GEL => "Georgian lari",
             Currency::GHS => "Ghanaian cedi",
             Currency::GIP => "Gibraltar pound",
@@ -339,6 +346,7 @@ impl Currency {
             Currency::UAH => "Ukrainian hryvnia",
             Currency::UGX => "Ugandan shilling",
             Currency::USD => "United States dollar",
+            Currency::USX => "United States penny",
             Currency::USN => "United States dollar",
             Currency::UYI => "Uruguay Peso en Unidades Indexadas",
             Currency::UYU => "Uruguayan peso",

--- a/rust/src/exchange/iso10383.rs
+++ b/rust/src/exchange/iso10383.rs
@@ -1,7 +1,9 @@
 use crate::CountryCode;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum MIC {
     // NYSE

--- a/rust/src/instrument/mod.rs
+++ b/rust/src/instrument/mod.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum InstrumentType {
     Spot,    // single instrument

--- a/rust/src/sector/industry.rs
+++ b/rust/src/sector/industry.rs
@@ -1,7 +1,9 @@
 use super::{IndustryGroup, SubIndustry};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum Industry {
     // Energy

--- a/rust/src/sector/industry_group.rs
+++ b/rust/src/sector/industry_group.rs
@@ -1,7 +1,9 @@
 use super::{Industry, Sector};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum IndustryGroup {
     // Energy

--- a/rust/src/sector/sector.rs
+++ b/rust/src/sector/sector.rs
@@ -41,7 +41,9 @@ use serde::{Deserialize, Serialize};
 //     }
 // }
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum Sector {
     Energy,

--- a/rust/src/sector/subindustry.rs
+++ b/rust/src/sector/subindustry.rs
@@ -1,7 +1,9 @@
 use super::Industry;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum SubIndustry {
     // Energy -> Energy Equipment and Services

--- a/rust/src/security/bond.rs
+++ b/rust/src/security/bond.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum BondType {
     Corporate,

--- a/rust/src/security/commodity.rs
+++ b/rust/src/security/commodity.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum CommodityType {
     Energy,
@@ -9,7 +11,7 @@ pub enum CommodityType {
 }
 
 // TODO
-// #[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+// #[derive(Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
 // #[strum(serialize_all = "PascalCase")]
 // pub enum CommoditySubType {
 //     EnergyType(Energy),
@@ -17,7 +19,9 @@ pub enum CommodityType {
 //     AgricultureType(Agriculture),
 // }
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum Energy {
     Crude,
@@ -26,7 +30,9 @@ pub enum Energy {
     NaturalGas,
 }
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum Metals {
     Gold,
@@ -36,7 +42,9 @@ pub enum Metals {
     Palladium,
 }
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum Agriculture {
     Corn,

--- a/rust/src/security/equity.rs
+++ b/rust/src/security/equity.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum EquityType {
     Shares,

--- a/rust/src/security/fund.rs
+++ b/rust/src/security/fund.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum FundType {
     ETF,
@@ -8,7 +10,9 @@ pub enum FundType {
     REIT,
 }
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum FundSubType {
     Index,
@@ -17,7 +21,9 @@ pub enum FundSubType {
     Passive,
 }
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum MutualFundEndedness {
     Open,

--- a/rust/src/security/future.rs
+++ b/rust/src/security/future.rs
@@ -1,13 +1,17 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum FutureType {
     Financial,
     Commodity,
 }
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum FutureDeliveryType {
     Physical,

--- a/rust/src/security/option.rs
+++ b/rust/src/security/option.rs
@@ -1,13 +1,17 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum OptionType {
     Call,
     Put,
 }
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum OptionExerciseType {
     American,

--- a/rust/src/security/security.rs
+++ b/rust/src/security/security.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum SecurityType {
     Equity,

--- a/rust/src/trading/mod.rs
+++ b/rust/src/trading/mod.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum OrderType {
     Market,
@@ -8,21 +10,27 @@ pub enum OrderType {
     Stop,
 }
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum Side {
     Buy,
     Sell,
 }
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum TimeInForce {
     Day,
     GTC,
 }
 
-#[derive(Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Display, EnumIter, EnumString, Eq, PartialEq, Serialize,
+)]
 #[strum(serialize_all = "PascalCase")]
 pub enum OrderFlag {
     None,

--- a/src/country/mod.rs
+++ b/src/country/mod.rs
@@ -1,4 +1,7 @@
+#![allow(non_snake_case)]
+
 use pyo3::prelude::*;
+use pyo3::class::basic::CompareOp;
 use pyo3::types::PyType;
 use strum::IntoEnumIterator;
 use std::str::FromStr;
@@ -36,8 +39,15 @@ impl Country {
         Ok(format!("Country<{}>", self.code.to_string()))
     }
 
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.code == other.code
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.code.to_string() < other.code.to_string()),
+            CompareOp::Le => Ok(self.code.to_string() <= other.code.to_string()),
+            CompareOp::Eq => Ok(self.code == other.code),
+            CompareOp::Ne => Ok(self.code != other.code),
+            CompareOp::Gt => Ok(self.code.to_string() > other.code.to_string()),
+            CompareOp::Ge => Ok(self.code.to_string() >= other.code.to_string()),
+        }
     }
 
     #[getter]
@@ -73,7 +83,6 @@ impl Country {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn AF() -> Country {
         Country {
             code: CountryCode::AF,
@@ -82,7 +91,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AX() -> Country {
         Country {
             code: CountryCode::AX,
@@ -91,7 +99,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AL() -> Country {
         Country {
             code: CountryCode::AL,
@@ -100,7 +107,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DZ() -> Country {
         Country {
             code: CountryCode::DZ,
@@ -109,7 +115,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AS() -> Country {
         Country {
             code: CountryCode::AS,
@@ -118,7 +123,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AD() -> Country {
         Country {
             code: CountryCode::AD,
@@ -127,7 +131,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AO() -> Country {
         Country {
             code: CountryCode::AO,
@@ -136,7 +139,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AI() -> Country {
         Country {
             code: CountryCode::AI,
@@ -145,7 +147,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AQ() -> Country {
         Country {
             code: CountryCode::AQ,
@@ -154,7 +155,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AG() -> Country {
         Country {
             code: CountryCode::AG,
@@ -163,7 +163,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AR() -> Country {
         Country {
             code: CountryCode::AR,
@@ -172,7 +171,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AM() -> Country {
         Country {
             code: CountryCode::AM,
@@ -181,7 +179,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AW() -> Country {
         Country {
             code: CountryCode::AW,
@@ -190,7 +187,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AU() -> Country {
         Country {
             code: CountryCode::AU,
@@ -199,7 +195,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AT() -> Country {
         Country {
             code: CountryCode::AT,
@@ -208,7 +203,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AZ() -> Country {
         Country {
             code: CountryCode::AZ,
@@ -217,7 +211,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BS() -> Country {
         Country {
             code: CountryCode::BS,
@@ -226,7 +219,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BH() -> Country {
         Country {
             code: CountryCode::BH,
@@ -235,7 +227,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BD() -> Country {
         Country {
             code: CountryCode::BD,
@@ -244,7 +235,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BB() -> Country {
         Country {
             code: CountryCode::BB,
@@ -253,7 +243,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BY() -> Country {
         Country {
             code: CountryCode::BY,
@@ -262,7 +251,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BE() -> Country {
         Country {
             code: CountryCode::BE,
@@ -271,7 +259,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BZ() -> Country {
         Country {
             code: CountryCode::BZ,
@@ -280,7 +267,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BJ() -> Country {
         Country {
             code: CountryCode::BJ,
@@ -289,7 +275,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BM() -> Country {
         Country {
             code: CountryCode::BM,
@@ -298,7 +283,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BT() -> Country {
         Country {
             code: CountryCode::BT,
@@ -307,7 +291,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BO() -> Country {
         Country {
             code: CountryCode::BO,
@@ -316,7 +299,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BQ() -> Country {
         Country {
             code: CountryCode::BQ,
@@ -325,7 +307,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BA() -> Country {
         Country {
             code: CountryCode::BA,
@@ -334,7 +315,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BW() -> Country {
         Country {
             code: CountryCode::BW,
@@ -343,7 +323,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BV() -> Country {
         Country {
             code: CountryCode::BV,
@@ -352,7 +331,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BR() -> Country {
         Country {
             code: CountryCode::BR,
@@ -361,7 +339,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IO() -> Country {
         Country {
             code: CountryCode::IO,
@@ -370,7 +347,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BN() -> Country {
         Country {
             code: CountryCode::BN,
@@ -379,7 +355,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BG() -> Country {
         Country {
             code: CountryCode::BG,
@@ -388,7 +363,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BF() -> Country {
         Country {
             code: CountryCode::BF,
@@ -397,7 +371,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BI() -> Country {
         Country {
             code: CountryCode::BI,
@@ -406,7 +379,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CV() -> Country {
         Country {
             code: CountryCode::CV,
@@ -415,7 +387,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KH() -> Country {
         Country {
             code: CountryCode::KH,
@@ -424,7 +395,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CM() -> Country {
         Country {
             code: CountryCode::CM,
@@ -433,7 +403,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CA() -> Country {
         Country {
             code: CountryCode::CA,
@@ -442,7 +411,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KY() -> Country {
         Country {
             code: CountryCode::KY,
@@ -451,7 +419,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CF() -> Country {
         Country {
             code: CountryCode::CF,
@@ -460,7 +427,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TD() -> Country {
         Country {
             code: CountryCode::TD,
@@ -469,7 +435,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CL() -> Country {
         Country {
             code: CountryCode::CL,
@@ -478,7 +443,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CN() -> Country {
         Country {
             code: CountryCode::CN,
@@ -487,7 +451,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CX() -> Country {
         Country {
             code: CountryCode::CX,
@@ -496,7 +459,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CC() -> Country {
         Country {
             code: CountryCode::CC,
@@ -505,7 +467,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CO() -> Country {
         Country {
             code: CountryCode::CO,
@@ -514,7 +475,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KM() -> Country {
         Country {
             code: CountryCode::KM,
@@ -523,7 +483,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CG() -> Country {
         Country {
             code: CountryCode::CG,
@@ -532,7 +491,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CD() -> Country {
         Country {
             code: CountryCode::CD,
@@ -541,7 +499,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CK() -> Country {
         Country {
             code: CountryCode::CK,
@@ -550,7 +507,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CR() -> Country {
         Country {
             code: CountryCode::CR,
@@ -559,7 +515,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CI() -> Country {
         Country {
             code: CountryCode::CI,
@@ -568,7 +523,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HR() -> Country {
         Country {
             code: CountryCode::HR,
@@ -577,7 +531,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CU() -> Country {
         Country {
             code: CountryCode::CU,
@@ -586,7 +539,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CW() -> Country {
         Country {
             code: CountryCode::CW,
@@ -595,7 +547,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CY() -> Country {
         Country {
             code: CountryCode::CY,
@@ -604,7 +555,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CZ() -> Country {
         Country {
             code: CountryCode::CZ,
@@ -613,7 +563,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DK() -> Country {
         Country {
             code: CountryCode::DK,
@@ -622,7 +571,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DJ() -> Country {
         Country {
             code: CountryCode::DJ,
@@ -631,7 +579,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DM() -> Country {
         Country {
             code: CountryCode::DM,
@@ -640,7 +587,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DO() -> Country {
         Country {
             code: CountryCode::DO,
@@ -649,7 +595,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn EC() -> Country {
         Country {
             code: CountryCode::EC,
@@ -658,7 +603,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn EG() -> Country {
         Country {
             code: CountryCode::EG,
@@ -667,7 +611,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SV() -> Country {
         Country {
             code: CountryCode::SV,
@@ -676,7 +619,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GQ() -> Country {
         Country {
             code: CountryCode::GQ,
@@ -685,7 +627,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ER() -> Country {
         Country {
             code: CountryCode::ER,
@@ -694,7 +635,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn EE() -> Country {
         Country {
             code: CountryCode::EE,
@@ -703,7 +643,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SZ() -> Country {
         Country {
             code: CountryCode::SZ,
@@ -712,7 +651,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ET() -> Country {
         Country {
             code: CountryCode::ET,
@@ -721,7 +659,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn FK() -> Country {
         Country {
             code: CountryCode::FK,
@@ -730,7 +667,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn FO() -> Country {
         Country {
             code: CountryCode::FO,
@@ -739,7 +675,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn FJ() -> Country {
         Country {
             code: CountryCode::FJ,
@@ -748,7 +683,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn FI() -> Country {
         Country {
             code: CountryCode::FI,
@@ -757,7 +691,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn FR() -> Country {
         Country {
             code: CountryCode::FR,
@@ -766,7 +699,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GF() -> Country {
         Country {
             code: CountryCode::GF,
@@ -775,7 +707,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PF() -> Country {
         Country {
             code: CountryCode::PF,
@@ -784,7 +715,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TF() -> Country {
         Country {
             code: CountryCode::TF,
@@ -793,7 +723,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GA() -> Country {
         Country {
             code: CountryCode::GA,
@@ -802,7 +731,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GM() -> Country {
         Country {
             code: CountryCode::GM,
@@ -811,7 +739,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GE() -> Country {
         Country {
             code: CountryCode::GE,
@@ -820,7 +747,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DE() -> Country {
         Country {
             code: CountryCode::DE,
@@ -829,7 +755,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GH() -> Country {
         Country {
             code: CountryCode::GH,
@@ -838,7 +763,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GI() -> Country {
         Country {
             code: CountryCode::GI,
@@ -847,7 +771,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GR() -> Country {
         Country {
             code: CountryCode::GR,
@@ -856,7 +779,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GL() -> Country {
         Country {
             code: CountryCode::GL,
@@ -865,7 +787,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GD() -> Country {
         Country {
             code: CountryCode::GD,
@@ -874,7 +795,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GP() -> Country {
         Country {
             code: CountryCode::GP,
@@ -883,7 +803,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GU() -> Country {
         Country {
             code: CountryCode::GU,
@@ -892,7 +811,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GT() -> Country {
         Country {
             code: CountryCode::GT,
@@ -901,7 +819,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GG() -> Country {
         Country {
             code: CountryCode::GG,
@@ -910,7 +827,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GN() -> Country {
         Country {
             code: CountryCode::GN,
@@ -919,7 +835,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GW() -> Country {
         Country {
             code: CountryCode::GW,
@@ -928,7 +843,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GY() -> Country {
         Country {
             code: CountryCode::GY,
@@ -937,7 +851,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HT() -> Country {
         Country {
             code: CountryCode::HT,
@@ -946,7 +859,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HM() -> Country {
         Country {
             code: CountryCode::HM,
@@ -955,7 +867,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn VA() -> Country {
         Country {
             code: CountryCode::VA,
@@ -964,7 +875,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HN() -> Country {
         Country {
             code: CountryCode::HN,
@@ -973,7 +883,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HK() -> Country {
         Country {
             code: CountryCode::HK,
@@ -982,7 +891,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HU() -> Country {
         Country {
             code: CountryCode::HU,
@@ -991,7 +899,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IS() -> Country {
         Country {
             code: CountryCode::IS,
@@ -1000,7 +907,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IN() -> Country {
         Country {
             code: CountryCode::IN,
@@ -1009,7 +915,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ID() -> Country {
         Country {
             code: CountryCode::ID,
@@ -1018,7 +923,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IR() -> Country {
         Country {
             code: CountryCode::IR,
@@ -1027,7 +931,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IQ() -> Country {
         Country {
             code: CountryCode::IQ,
@@ -1036,7 +939,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IE() -> Country {
         Country {
             code: CountryCode::IE,
@@ -1045,7 +947,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IM() -> Country {
         Country {
             code: CountryCode::IM,
@@ -1054,7 +955,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IL() -> Country {
         Country {
             code: CountryCode::IL,
@@ -1063,7 +963,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IT() -> Country {
         Country {
             code: CountryCode::IT,
@@ -1072,7 +971,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn JM() -> Country {
         Country {
             code: CountryCode::JM,
@@ -1081,7 +979,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn JP() -> Country {
         Country {
             code: CountryCode::JP,
@@ -1090,7 +987,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn JE() -> Country {
         Country {
             code: CountryCode::JE,
@@ -1099,7 +995,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn JO() -> Country {
         Country {
             code: CountryCode::JO,
@@ -1108,7 +1003,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KZ() -> Country {
         Country {
             code: CountryCode::KZ,
@@ -1117,7 +1011,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KE() -> Country {
         Country {
             code: CountryCode::KE,
@@ -1126,7 +1019,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KI() -> Country {
         Country {
             code: CountryCode::KI,
@@ -1135,7 +1027,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KP() -> Country {
         Country {
             code: CountryCode::KP,
@@ -1144,7 +1035,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KR() -> Country {
         Country {
             code: CountryCode::KR,
@@ -1153,7 +1043,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KW() -> Country {
         Country {
             code: CountryCode::KW,
@@ -1162,7 +1051,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KG() -> Country {
         Country {
             code: CountryCode::KG,
@@ -1171,7 +1059,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LA() -> Country {
         Country {
             code: CountryCode::LA,
@@ -1180,7 +1067,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LV() -> Country {
         Country {
             code: CountryCode::LV,
@@ -1189,7 +1075,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LB() -> Country {
         Country {
             code: CountryCode::LB,
@@ -1198,7 +1083,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LS() -> Country {
         Country {
             code: CountryCode::LS,
@@ -1207,7 +1091,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LR() -> Country {
         Country {
             code: CountryCode::LR,
@@ -1216,7 +1099,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LY() -> Country {
         Country {
             code: CountryCode::LY,
@@ -1225,7 +1107,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LI() -> Country {
         Country {
             code: CountryCode::LI,
@@ -1234,7 +1115,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LT() -> Country {
         Country {
             code: CountryCode::LT,
@@ -1243,7 +1123,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LU() -> Country {
         Country {
             code: CountryCode::LU,
@@ -1252,7 +1131,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MO() -> Country {
         Country {
             code: CountryCode::MO,
@@ -1261,7 +1139,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MG() -> Country {
         Country {
             code: CountryCode::MG,
@@ -1270,7 +1147,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MW() -> Country {
         Country {
             code: CountryCode::MW,
@@ -1279,7 +1155,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MY() -> Country {
         Country {
             code: CountryCode::MY,
@@ -1288,7 +1163,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MV() -> Country {
         Country {
             code: CountryCode::MV,
@@ -1297,7 +1171,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ML() -> Country {
         Country {
             code: CountryCode::ML,
@@ -1306,7 +1179,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MT() -> Country {
         Country {
             code: CountryCode::MT,
@@ -1315,7 +1187,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MH() -> Country {
         Country {
             code: CountryCode::MH,
@@ -1324,7 +1195,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MQ() -> Country {
         Country {
             code: CountryCode::MQ,
@@ -1333,7 +1203,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MR() -> Country {
         Country {
             code: CountryCode::MR,
@@ -1342,7 +1211,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MU() -> Country {
         Country {
             code: CountryCode::MU,
@@ -1351,7 +1219,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn YT() -> Country {
         Country {
             code: CountryCode::YT,
@@ -1360,7 +1227,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MX() -> Country {
         Country {
             code: CountryCode::MX,
@@ -1369,7 +1235,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn FM() -> Country {
         Country {
             code: CountryCode::FM,
@@ -1378,7 +1243,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MD() -> Country {
         Country {
             code: CountryCode::MD,
@@ -1387,7 +1251,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MC() -> Country {
         Country {
             code: CountryCode::MC,
@@ -1396,7 +1259,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MN() -> Country {
         Country {
             code: CountryCode::MN,
@@ -1405,7 +1267,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ME() -> Country {
         Country {
             code: CountryCode::ME,
@@ -1414,7 +1275,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MS() -> Country {
         Country {
             code: CountryCode::MS,
@@ -1423,7 +1283,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MA() -> Country {
         Country {
             code: CountryCode::MA,
@@ -1432,7 +1291,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MZ() -> Country {
         Country {
             code: CountryCode::MZ,
@@ -1441,7 +1299,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MM() -> Country {
         Country {
             code: CountryCode::MM,
@@ -1450,7 +1307,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NA() -> Country {
         Country {
             code: CountryCode::NA,
@@ -1459,7 +1315,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NR() -> Country {
         Country {
             code: CountryCode::NR,
@@ -1468,7 +1323,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NP() -> Country {
         Country {
             code: CountryCode::NP,
@@ -1477,7 +1331,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NL() -> Country {
         Country {
             code: CountryCode::NL,
@@ -1486,7 +1339,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NC() -> Country {
         Country {
             code: CountryCode::NC,
@@ -1495,7 +1347,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NZ() -> Country {
         Country {
             code: CountryCode::NZ,
@@ -1504,7 +1355,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NI() -> Country {
         Country {
             code: CountryCode::NI,
@@ -1513,7 +1363,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NE() -> Country {
         Country {
             code: CountryCode::NE,
@@ -1522,7 +1371,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NG() -> Country {
         Country {
             code: CountryCode::NG,
@@ -1531,7 +1379,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NU() -> Country {
         Country {
             code: CountryCode::NU,
@@ -1540,7 +1387,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NF() -> Country {
         Country {
             code: CountryCode::NF,
@@ -1549,7 +1395,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MK() -> Country {
         Country {
             code: CountryCode::MK,
@@ -1558,7 +1403,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MP() -> Country {
         Country {
             code: CountryCode::MP,
@@ -1567,7 +1411,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NO() -> Country {
         Country {
             code: CountryCode::NO,
@@ -1576,7 +1419,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn OM() -> Country {
         Country {
             code: CountryCode::OM,
@@ -1585,7 +1427,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PK() -> Country {
         Country {
             code: CountryCode::PK,
@@ -1594,7 +1435,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PW() -> Country {
         Country {
             code: CountryCode::PW,
@@ -1603,7 +1443,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PS() -> Country {
         Country {
             code: CountryCode::PS,
@@ -1612,7 +1451,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PA() -> Country {
         Country {
             code: CountryCode::PA,
@@ -1621,7 +1459,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PG() -> Country {
         Country {
             code: CountryCode::PG,
@@ -1630,7 +1467,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PY() -> Country {
         Country {
             code: CountryCode::PY,
@@ -1639,7 +1475,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PE() -> Country {
         Country {
             code: CountryCode::PE,
@@ -1648,7 +1483,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PH() -> Country {
         Country {
             code: CountryCode::PH,
@@ -1657,7 +1491,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PN() -> Country {
         Country {
             code: CountryCode::PN,
@@ -1666,7 +1499,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PL() -> Country {
         Country {
             code: CountryCode::PL,
@@ -1675,7 +1507,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PT() -> Country {
         Country {
             code: CountryCode::PT,
@@ -1684,7 +1515,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PR() -> Country {
         Country {
             code: CountryCode::PR,
@@ -1693,7 +1523,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn QA() -> Country {
         Country {
             code: CountryCode::QA,
@@ -1702,7 +1531,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RE() -> Country {
         Country {
             code: CountryCode::RE,
@@ -1711,7 +1539,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RO() -> Country {
         Country {
             code: CountryCode::RO,
@@ -1720,7 +1547,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RU() -> Country {
         Country {
             code: CountryCode::RU,
@@ -1729,7 +1555,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RW() -> Country {
         Country {
             code: CountryCode::RW,
@@ -1738,7 +1563,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BL() -> Country {
         Country {
             code: CountryCode::BL,
@@ -1747,7 +1571,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SH() -> Country {
         Country {
             code: CountryCode::SH,
@@ -1756,7 +1579,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KN() -> Country {
         Country {
             code: CountryCode::KN,
@@ -1765,7 +1587,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LC() -> Country {
         Country {
             code: CountryCode::LC,
@@ -1774,7 +1595,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MF() -> Country {
         Country {
             code: CountryCode::MF,
@@ -1783,7 +1603,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PM() -> Country {
         Country {
             code: CountryCode::PM,
@@ -1792,7 +1611,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn VC() -> Country {
         Country {
             code: CountryCode::VC,
@@ -1801,7 +1619,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn WS() -> Country {
         Country {
             code: CountryCode::WS,
@@ -1810,7 +1627,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SM() -> Country {
         Country {
             code: CountryCode::SM,
@@ -1819,7 +1635,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ST() -> Country {
         Country {
             code: CountryCode::ST,
@@ -1828,7 +1643,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SA() -> Country {
         Country {
             code: CountryCode::SA,
@@ -1837,7 +1651,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SN() -> Country {
         Country {
             code: CountryCode::SN,
@@ -1846,7 +1659,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RS() -> Country {
         Country {
             code: CountryCode::RS,
@@ -1855,7 +1667,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SC() -> Country {
         Country {
             code: CountryCode::SC,
@@ -1864,7 +1675,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SL() -> Country {
         Country {
             code: CountryCode::SL,
@@ -1873,7 +1683,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SG() -> Country {
         Country {
             code: CountryCode::SG,
@@ -1882,7 +1691,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SX() -> Country {
         Country {
             code: CountryCode::SX,
@@ -1891,7 +1699,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SK() -> Country {
         Country {
             code: CountryCode::SK,
@@ -1900,7 +1707,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SI() -> Country {
         Country {
             code: CountryCode::SI,
@@ -1909,7 +1715,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SB() -> Country {
         Country {
             code: CountryCode::SB,
@@ -1918,7 +1723,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SO() -> Country {
         Country {
             code: CountryCode::SO,
@@ -1927,7 +1731,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ZA() -> Country {
         Country {
             code: CountryCode::ZA,
@@ -1936,7 +1739,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GS() -> Country {
         Country {
             code: CountryCode::GS,
@@ -1945,7 +1747,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SS() -> Country {
         Country {
             code: CountryCode::SS,
@@ -1954,7 +1755,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ES() -> Country {
         Country {
             code: CountryCode::ES,
@@ -1963,7 +1763,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LK() -> Country {
         Country {
             code: CountryCode::LK,
@@ -1972,7 +1771,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SD() -> Country {
         Country {
             code: CountryCode::SD,
@@ -1981,7 +1779,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SR() -> Country {
         Country {
             code: CountryCode::SR,
@@ -1990,7 +1787,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SJ() -> Country {
         Country {
             code: CountryCode::SJ,
@@ -1999,7 +1795,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SE() -> Country {
         Country {
             code: CountryCode::SE,
@@ -2008,7 +1803,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CH() -> Country {
         Country {
             code: CountryCode::CH,
@@ -2017,7 +1811,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SY() -> Country {
         Country {
             code: CountryCode::SY,
@@ -2026,7 +1819,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TW() -> Country {
         Country {
             code: CountryCode::TW,
@@ -2035,7 +1827,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TJ() -> Country {
         Country {
             code: CountryCode::TJ,
@@ -2044,7 +1835,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TZ() -> Country {
         Country {
             code: CountryCode::TZ,
@@ -2053,7 +1843,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TH() -> Country {
         Country {
             code: CountryCode::TH,
@@ -2062,7 +1851,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TL() -> Country {
         Country {
             code: CountryCode::TL,
@@ -2071,7 +1859,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TG() -> Country {
         Country {
             code: CountryCode::TG,
@@ -2080,7 +1867,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TK() -> Country {
         Country {
             code: CountryCode::TK,
@@ -2089,7 +1875,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TO() -> Country {
         Country {
             code: CountryCode::TO,
@@ -2098,7 +1883,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TT() -> Country {
         Country {
             code: CountryCode::TT,
@@ -2107,7 +1891,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TN() -> Country {
         Country {
             code: CountryCode::TN,
@@ -2116,7 +1899,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TR() -> Country {
         Country {
             code: CountryCode::TR,
@@ -2125,7 +1907,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TM() -> Country {
         Country {
             code: CountryCode::TM,
@@ -2134,7 +1915,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TC() -> Country {
         Country {
             code: CountryCode::TC,
@@ -2143,7 +1923,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TV() -> Country {
         Country {
             code: CountryCode::TV,
@@ -2152,7 +1931,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn UG() -> Country {
         Country {
             code: CountryCode::UG,
@@ -2161,7 +1939,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn UA() -> Country {
         Country {
             code: CountryCode::UA,
@@ -2170,7 +1947,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AE() -> Country {
         Country {
             code: CountryCode::AE,
@@ -2179,7 +1955,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GB() -> Country {
         Country {
             code: CountryCode::GB,
@@ -2188,7 +1963,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn US() -> Country {
         Country {
             code: CountryCode::US,
@@ -2197,7 +1971,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn UM() -> Country {
         Country {
             code: CountryCode::UM,
@@ -2206,7 +1979,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn UY() -> Country {
         Country {
             code: CountryCode::UY,
@@ -2215,7 +1987,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn UZ() -> Country {
         Country {
             code: CountryCode::UZ,
@@ -2224,7 +1995,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn VU() -> Country {
         Country {
             code: CountryCode::VU,
@@ -2233,7 +2003,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn VE() -> Country {
         Country {
             code: CountryCode::VE,
@@ -2242,7 +2011,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn VN() -> Country {
         Country {
             code: CountryCode::VN,
@@ -2251,7 +2019,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn VG() -> Country {
         Country {
             code: CountryCode::VG,
@@ -2260,7 +2027,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn VI() -> Country {
         Country {
             code: CountryCode::VI,
@@ -2269,7 +2035,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn WF() -> Country {
         Country {
             code: CountryCode::WF,
@@ -2278,7 +2043,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn EH() -> Country {
         Country {
             code: CountryCode::EH,
@@ -2287,7 +2051,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn YE() -> Country {
         Country {
             code: CountryCode::YE,
@@ -2296,7 +2059,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ZM() -> Country {
         Country {
             code: CountryCode::ZM,
@@ -2305,7 +2067,6 @@ impl Country {
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ZW() -> Country {
         Country {
             code: CountryCode::ZW,

--- a/src/currency/mod.rs
+++ b/src/currency/mod.rs
@@ -1,4 +1,7 @@
+#![allow(non_snake_case)]
+
 use pyo3::prelude::*;
+use pyo3::class::basic::CompareOp;
 use pyo3::types::PyType;
 use strum::IntoEnumIterator;
 use std::str::FromStr;
@@ -14,9 +17,16 @@ pub struct Currency {
 impl Currency {
     #[new]
     fn py_new(value: String) -> PyResult<Self> {
+        let value_as_str = value.as_str();
+        let base_currency = match value_as_str {
+            "EUr" => BaseCurrency::EUX,
+            "GBp" => BaseCurrency::GBX,
+            "USd" => BaseCurrency::USX,
+            _ => BaseCurrency::from_str(value_as_str).unwrap()
+        };
         Ok(
             Currency {
-                code: BaseCurrency::from_str(value.as_str()).unwrap()
+                code: base_currency
             }
         )
 
@@ -30,8 +40,15 @@ impl Currency {
         Ok(format!("Currency<{}>", self.code.to_string()))
     }
 
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.code == other.code
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.code.to_string() < other.code.to_string()),
+            CompareOp::Le => Ok(self.code.to_string() <= other.code.to_string()),
+            CompareOp::Eq => Ok(self.code == other.code),
+            CompareOp::Ne => Ok(self.code != other.code),
+            CompareOp::Gt => Ok(self.code.to_string() > other.code.to_string()),
+            CompareOp::Ge => Ok(self.code.to_string() >= other.code.to_string()),
+        }
     }
 
     #[getter]
@@ -57,1260 +74,1098 @@ impl Currency {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn AED() -> Currency {
         Currency {
             code: BaseCurrency::AED
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AFN() -> Currency {
         Currency {
             code: BaseCurrency::AFN
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ALL() -> Currency {
         Currency {
             code: BaseCurrency::ALL
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AMD() -> Currency {
         Currency {
             code: BaseCurrency::AMD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ANG() -> Currency {
         Currency {
             code: BaseCurrency::ANG
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AOA() -> Currency {
         Currency {
             code: BaseCurrency::AOA
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ARS() -> Currency {
         Currency {
             code: BaseCurrency::ARS
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AUD() -> Currency {
         Currency {
             code: BaseCurrency::AUD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AWG() -> Currency {
         Currency {
             code: BaseCurrency::AWG
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AZN() -> Currency {
         Currency {
             code: BaseCurrency::AZN
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BAM() -> Currency {
         Currency {
             code: BaseCurrency::BAM
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BBD() -> Currency {
         Currency {
             code: BaseCurrency::BBD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BDT() -> Currency {
         Currency {
             code: BaseCurrency::BDT
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BGN() -> Currency {
         Currency {
             code: BaseCurrency::BGN
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BHD() -> Currency {
         Currency {
             code: BaseCurrency::BHD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BIF() -> Currency {
         Currency {
             code: BaseCurrency::BIF
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BMD() -> Currency {
         Currency {
             code: BaseCurrency::BMD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BND() -> Currency {
         Currency {
             code: BaseCurrency::BND
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BOB() -> Currency {
         Currency {
             code: BaseCurrency::BOB
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BOV() -> Currency {
         Currency {
             code: BaseCurrency::BOV
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BRL() -> Currency {
         Currency {
             code: BaseCurrency::BRL
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BSD() -> Currency {
         Currency {
             code: BaseCurrency::BSD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BTN() -> Currency {
         Currency {
             code: BaseCurrency::BTN
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BWP() -> Currency {
         Currency {
             code: BaseCurrency::BWP
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BYN() -> Currency {
         Currency {
             code: BaseCurrency::BYN
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BZD() -> Currency {
         Currency {
             code: BaseCurrency::BZD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CAD() -> Currency {
         Currency {
             code: BaseCurrency::CAD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CDF() -> Currency {
         Currency {
             code: BaseCurrency::CDF
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CHE() -> Currency {
         Currency {
             code: BaseCurrency::CHE
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CHF() -> Currency {
         Currency {
             code: BaseCurrency::CHF
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CHW() -> Currency {
         Currency {
             code: BaseCurrency::CHW
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CLF() -> Currency {
         Currency {
             code: BaseCurrency::CLF
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CLP() -> Currency {
         Currency {
             code: BaseCurrency::CLP
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn COP() -> Currency {
         Currency {
             code: BaseCurrency::COP
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn COU() -> Currency {
         Currency {
             code: BaseCurrency::COU
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CRC() -> Currency {
         Currency {
             code: BaseCurrency::CRC
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CUC() -> Currency {
         Currency {
             code: BaseCurrency::CUC
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CUP() -> Currency {
         Currency {
             code: BaseCurrency::CUP
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CVE() -> Currency {
         Currency {
             code: BaseCurrency::CVE
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CZK() -> Currency {
         Currency {
             code: BaseCurrency::CZK
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DJF() -> Currency {
         Currency {
             code: BaseCurrency::DJF
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DKK() -> Currency {
         Currency {
             code: BaseCurrency::DKK
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DOP() -> Currency {
         Currency {
             code: BaseCurrency::DOP
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DZD() -> Currency {
         Currency {
             code: BaseCurrency::DZD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn EGP() -> Currency {
         Currency {
             code: BaseCurrency::EGP
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ERN() -> Currency {
         Currency {
             code: BaseCurrency::ERN
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ETB() -> Currency {
         Currency {
             code: BaseCurrency::ETB
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn EUR() -> Currency {
         Currency {
             code: BaseCurrency::EUR
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
+    fn EUX() -> Currency {
+        Currency {
+            code: BaseCurrency::EUX
+        }
+    }
+    #[classattr]
     fn FJD() -> Currency {
         Currency {
             code: BaseCurrency::FJD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn FKP() -> Currency {
         Currency {
             code: BaseCurrency::FKP
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GBP() -> Currency {
         Currency {
             code: BaseCurrency::GBP
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
+    fn GBX() -> Currency {
+        Currency {
+            code: BaseCurrency::GBX
+        }
+    }
+    #[classattr]
     fn GEL() -> Currency {
         Currency {
             code: BaseCurrency::GEL
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GHS() -> Currency {
         Currency {
             code: BaseCurrency::GHS
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GIP() -> Currency {
         Currency {
             code: BaseCurrency::GIP
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GMD() -> Currency {
         Currency {
             code: BaseCurrency::GMD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GNF() -> Currency {
         Currency {
             code: BaseCurrency::GNF
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GTQ() -> Currency {
         Currency {
             code: BaseCurrency::GTQ
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GYD() -> Currency {
         Currency {
             code: BaseCurrency::GYD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HKD() -> Currency {
         Currency {
             code: BaseCurrency::HKD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HNL() -> Currency {
         Currency {
             code: BaseCurrency::HNL
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HTG() -> Currency {
         Currency {
             code: BaseCurrency::HTG
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HUF() -> Currency {
         Currency {
             code: BaseCurrency::HUF
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IDR() -> Currency {
         Currency {
             code: BaseCurrency::IDR
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ILS() -> Currency {
         Currency {
             code: BaseCurrency::ILS
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn INR() -> Currency {
         Currency {
             code: BaseCurrency::INR
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IQD() -> Currency {
         Currency {
             code: BaseCurrency::IQD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IRR() -> Currency {
         Currency {
             code: BaseCurrency::IRR
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ISK() -> Currency {
         Currency {
             code: BaseCurrency::ISK
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn JMD() -> Currency {
         Currency {
             code: BaseCurrency::JMD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn JOD() -> Currency {
         Currency {
             code: BaseCurrency::JOD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn JPY() -> Currency {
         Currency {
             code: BaseCurrency::JPY
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KES() -> Currency {
         Currency {
             code: BaseCurrency::KES
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KGS() -> Currency {
         Currency {
             code: BaseCurrency::KGS
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KHR() -> Currency {
         Currency {
             code: BaseCurrency::KHR
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KMF() -> Currency {
         Currency {
             code: BaseCurrency::KMF
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KPW() -> Currency {
         Currency {
             code: BaseCurrency::KPW
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KRW() -> Currency {
         Currency {
             code: BaseCurrency::KRW
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KWD() -> Currency {
         Currency {
             code: BaseCurrency::KWD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KYD() -> Currency {
         Currency {
             code: BaseCurrency::KYD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn KZT() -> Currency {
         Currency {
             code: BaseCurrency::KZT
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LAK() -> Currency {
         Currency {
             code: BaseCurrency::LAK
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LBP() -> Currency {
         Currency {
             code: BaseCurrency::LBP
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LKR() -> Currency {
         Currency {
             code: BaseCurrency::LKR
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LRD() -> Currency {
         Currency {
             code: BaseCurrency::LRD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LSL() -> Currency {
         Currency {
             code: BaseCurrency::LSL
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LYD() -> Currency {
         Currency {
             code: BaseCurrency::LYD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MAD() -> Currency {
         Currency {
             code: BaseCurrency::MAD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MDL() -> Currency {
         Currency {
             code: BaseCurrency::MDL
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MGA() -> Currency {
         Currency {
             code: BaseCurrency::MGA
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MKD() -> Currency {
         Currency {
             code: BaseCurrency::MKD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MMK() -> Currency {
         Currency {
             code: BaseCurrency::MMK
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MNT() -> Currency {
         Currency {
             code: BaseCurrency::MNT
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MOP() -> Currency {
         Currency {
             code: BaseCurrency::MOP
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MRU() -> Currency {
         Currency {
             code: BaseCurrency::MRU
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MUR() -> Currency {
         Currency {
             code: BaseCurrency::MUR
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MVR() -> Currency {
         Currency {
             code: BaseCurrency::MVR
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MWK() -> Currency {
         Currency {
             code: BaseCurrency::MWK
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MXN() -> Currency {
         Currency {
             code: BaseCurrency::MXN
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MXV() -> Currency {
         Currency {
             code: BaseCurrency::MXV
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MYR() -> Currency {
         Currency {
             code: BaseCurrency::MYR
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MZN() -> Currency {
         Currency {
             code: BaseCurrency::MZN
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NAD() -> Currency {
         Currency {
             code: BaseCurrency::NAD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NGN() -> Currency {
         Currency {
             code: BaseCurrency::NGN
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NIO() -> Currency {
         Currency {
             code: BaseCurrency::NIO
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NOK() -> Currency {
         Currency {
             code: BaseCurrency::NOK
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NPR() -> Currency {
         Currency {
             code: BaseCurrency::NPR
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn NZD() -> Currency {
         Currency {
             code: BaseCurrency::NZD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn OMR() -> Currency {
         Currency {
             code: BaseCurrency::OMR
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PAB() -> Currency {
         Currency {
             code: BaseCurrency::PAB
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PEN() -> Currency {
         Currency {
             code: BaseCurrency::PEN
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PGK() -> Currency {
         Currency {
             code: BaseCurrency::PGK
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PHP() -> Currency {
         Currency {
             code: BaseCurrency::PHP
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PKR() -> Currency {
         Currency {
             code: BaseCurrency::PKR
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PLN() -> Currency {
         Currency {
             code: BaseCurrency::PLN
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PYG() -> Currency {
         Currency {
             code: BaseCurrency::PYG
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn QAR() -> Currency {
         Currency {
             code: BaseCurrency::QAR
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RON() -> Currency {
         Currency {
             code: BaseCurrency::RON
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RSD() -> Currency {
         Currency {
             code: BaseCurrency::RSD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CNY() -> Currency {
         Currency {
             code: BaseCurrency::CNY
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RUB() -> Currency {
         Currency {
             code: BaseCurrency::RUB
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RWF() -> Currency {
         Currency {
             code: BaseCurrency::RWF
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SAR() -> Currency {
         Currency {
             code: BaseCurrency::SAR
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SBD() -> Currency {
         Currency {
             code: BaseCurrency::SBD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SCR() -> Currency {
         Currency {
             code: BaseCurrency::SCR
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SDG() -> Currency {
         Currency {
             code: BaseCurrency::SDG
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SEK() -> Currency {
         Currency {
             code: BaseCurrency::SEK
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SGD() -> Currency {
         Currency {
             code: BaseCurrency::SGD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SHP() -> Currency {
         Currency {
             code: BaseCurrency::SHP
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SLE() -> Currency {
         Currency {
             code: BaseCurrency::SLE
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SLL() -> Currency {
         Currency {
             code: BaseCurrency::SLL
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SOS() -> Currency {
         Currency {
             code: BaseCurrency::SOS
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SRD() -> Currency {
         Currency {
             code: BaseCurrency::SRD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SSP() -> Currency {
         Currency {
             code: BaseCurrency::SSP
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn STN() -> Currency {
         Currency {
             code: BaseCurrency::STN
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SVC() -> Currency {
         Currency {
             code: BaseCurrency::SVC
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SYP() -> Currency {
         Currency {
             code: BaseCurrency::SYP
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SZL() -> Currency {
         Currency {
             code: BaseCurrency::SZL
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn THB() -> Currency {
         Currency {
             code: BaseCurrency::THB
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TJS() -> Currency {
         Currency {
             code: BaseCurrency::TJS
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TMT() -> Currency {
         Currency {
             code: BaseCurrency::TMT
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TND() -> Currency {
         Currency {
             code: BaseCurrency::TND
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TOP() -> Currency {
         Currency {
             code: BaseCurrency::TOP
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TRY() -> Currency {
         Currency {
             code: BaseCurrency::TRY
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TTD() -> Currency {
         Currency {
             code: BaseCurrency::TTD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TWD() -> Currency {
         Currency {
             code: BaseCurrency::TWD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TZS() -> Currency {
         Currency {
             code: BaseCurrency::TZS
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn UAH() -> Currency {
         Currency {
             code: BaseCurrency::UAH
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn UGX() -> Currency {
         Currency {
             code: BaseCurrency::UGX
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn USD() -> Currency {
         Currency {
             code: BaseCurrency::USD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
+    fn USX() -> Currency {
+        Currency {
+            code: BaseCurrency::USX
+        }
+    }
+    #[classattr]
     fn USN() -> Currency {
         Currency {
             code: BaseCurrency::USN
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn UYI() -> Currency {
         Currency {
             code: BaseCurrency::UYI
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn UYU() -> Currency {
         Currency {
             code: BaseCurrency::UYU
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn UYW() -> Currency {
         Currency {
             code: BaseCurrency::UYW
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn UZS() -> Currency {
         Currency {
             code: BaseCurrency::UZS
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn VED() -> Currency {
         Currency {
             code: BaseCurrency::VED
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn VES() -> Currency {
         Currency {
             code: BaseCurrency::VES
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn VND() -> Currency {
         Currency {
             code: BaseCurrency::VND
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn VUV() -> Currency {
         Currency {
             code: BaseCurrency::VUV
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn WST() -> Currency {
         Currency {
             code: BaseCurrency::WST
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XAF() -> Currency {
         Currency {
             code: BaseCurrency::XAF
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XAG() -> Currency {
         Currency {
             code: BaseCurrency::XAG
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XAU() -> Currency {
         Currency {
             code: BaseCurrency::XAU
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XBA() -> Currency {
         Currency {
             code: BaseCurrency::XBA
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XBB() -> Currency {
         Currency {
             code: BaseCurrency::XBB
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XBC() -> Currency {
         Currency {
             code: BaseCurrency::XBC
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XBD() -> Currency {
         Currency {
             code: BaseCurrency::XBD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XCD() -> Currency {
         Currency {
             code: BaseCurrency::XCD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XDR() -> Currency {
         Currency {
             code: BaseCurrency::XDR
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XOF() -> Currency {
         Currency {
             code: BaseCurrency::XOF
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XPD() -> Currency {
         Currency {
             code: BaseCurrency::XPD
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XPF() -> Currency {
         Currency {
             code: BaseCurrency::XPF
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XPT() -> Currency {
         Currency {
             code: BaseCurrency::XPT
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XSU() -> Currency {
         Currency {
             code: BaseCurrency::XSU
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XTS() -> Currency {
         Currency {
             code: BaseCurrency::XTS
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XUA() -> Currency {
         Currency {
             code: BaseCurrency::XUA
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XXX() -> Currency {
         Currency {
             code: BaseCurrency::XXX
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn YER() -> Currency {
         Currency {
             code: BaseCurrency::YER
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ZAR() -> Currency {
         Currency {
             code: BaseCurrency::ZAR
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ZMW() -> Currency {
         Currency {
             code: BaseCurrency::ZMW
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ZWL() -> Currency {
         Currency {
             code: BaseCurrency::ZWL

--- a/src/exchange/mod.rs
+++ b/src/exchange/mod.rs
@@ -1,4 +1,7 @@
+#![allow(non_snake_case)]
+
 use pyo3::prelude::*;
+use pyo3::class::basic::CompareOp;
 use pyo3::types::PyType;
 use strum::IntoEnumIterator;
 use std::str::FromStr;
@@ -31,9 +34,16 @@ impl Exchange {
         Ok(format!("Exchange<{}>", self.mic.to_string()))
     }
 
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.mic == other.mic
-    }
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.mic.to_string() < other.mic.to_string()),
+            CompareOp::Le => Ok(self.mic.to_string() <= other.mic.to_string()),
+            CompareOp::Eq => Ok(self.mic == other.mic),
+            CompareOp::Ne => Ok(self.mic != other.mic),
+            CompareOp::Gt => Ok(self.mic.to_string() > other.mic.to_string()),
+            CompareOp::Ge => Ok(self.mic.to_string() >= other.mic.to_string()),
+        }
+    }    
 
     fn country(&self) -> Country {
         Country {
@@ -56,147 +66,126 @@ impl Exchange {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn XNYS() -> Exchange {
         Exchange {
             mic: MIC::XNYS
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ARCX() -> Exchange {
         Exchange {
             mic: MIC::ARCX
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XASE() -> Exchange {
         Exchange {
             mic: MIC::XASE
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XCIS() -> Exchange {
         Exchange {
             mic: MIC::XCIS
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XCHI() -> Exchange {
         Exchange {
             mic: MIC::XCHI
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XNAS() -> Exchange {
         Exchange {
             mic: MIC::XNAS
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XNGS() -> Exchange {
         Exchange {
             mic: MIC::XNGS
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XBOS() -> Exchange {
         Exchange {
             mic: MIC::XBOS
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XPHL() -> Exchange {
         Exchange {
             mic: MIC::XPHL
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XCBO() -> Exchange {
         Exchange {
             mic: MIC::XCBO
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BATS() -> Exchange {
         Exchange {
             mic: MIC::BATS
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BATY() -> Exchange {
         Exchange {
             mic: MIC::BATY
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn EDGX() -> Exchange {
         Exchange {
             mic: MIC::EDGX
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn EDGA() -> Exchange {
         Exchange {
             mic: MIC::EDGA
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MPRL() -> Exchange {
         Exchange {
             mic: MIC::MPRL
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MIHI() -> Exchange {
         Exchange {
             mic: MIC::MIHI
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MEMX() -> Exchange {
         Exchange {
             mic: MIC::MEMX
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IEXG() -> Exchange {
         Exchange {
             mic: MIC::IEXG
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LTSE() -> Exchange {
         Exchange {
             mic: MIC::LTSE
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn XADF() -> Exchange {
         Exchange {
             mic: MIC::XADF
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn FINR() -> Exchange {
         Exchange {
             mic: MIC::FINR

--- a/src/sector/industry.rs
+++ b/src/sector/industry.rs
@@ -1,4 +1,7 @@
+#![allow(non_snake_case)]
+
 use pyo3::prelude::*;
+use pyo3::class::basic::CompareOp;
 use pyo3::types::PyType;
 use strum::IntoEnumIterator;
 use std::str::FromStr;
@@ -31,9 +34,16 @@ impl Industry {
         Ok(format!("Industry<{}>", self.typ.to_string()))
     }
 
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.typ == other.typ
-    }
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.typ.to_string() < other.typ.to_string()),
+            CompareOp::Le => Ok(self.typ.to_string() <= other.typ.to_string()),
+            CompareOp::Eq => Ok(self.typ == other.typ),
+            CompareOp::Ne => Ok(self.typ != other.typ),
+            CompareOp::Gt => Ok(self.typ.to_string() > other.typ.to_string()),
+            CompareOp::Ge => Ok(self.typ.to_string() >= other.typ.to_string()),
+        }
+    }    
 
     fn industry_group(&self) -> IndustryGroup {
         IndustryGroup {
@@ -58,518 +68,444 @@ impl Industry {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn EnergyEquipmentAndServices() -> Industry {
         Industry {
             typ: BaseIndustry::EnergyEquipmentAndServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn OilGasAndConsumeableFules() -> Industry {
         Industry {
             typ: BaseIndustry::OilGasAndConsumeableFules
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Chemicals() -> Industry {
         Industry {
             typ: BaseIndustry::Chemicals
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ConstructionMaterials() -> Industry {
         Industry {
             typ: BaseIndustry::ConstructionMaterials
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ContainersAndPackaging() -> Industry {
         Industry {
             typ: BaseIndustry::ContainersAndPackaging
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MetalsAndMining() -> Industry {
         Industry {
             typ: BaseIndustry::MetalsAndMining
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PaperAndForestProducts() -> Industry {
         Industry {
             typ: BaseIndustry::PaperAndForestProducts
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AerospaceAndDefense() -> Industry {
         Industry {
             typ: BaseIndustry::AerospaceAndDefense
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BuildingProducts() -> Industry {
         Industry {
             typ: BaseIndustry::BuildingProducts
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ConstructionAndEngineering() -> Industry {
         Industry {
             typ: BaseIndustry::ConstructionAndEngineering
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ElectricalEquipment() -> Industry {
         Industry {
             typ: BaseIndustry::ElectricalEquipment
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IndustrialConglomerates() -> Industry {
         Industry {
             typ: BaseIndustry::IndustrialConglomerates
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Machinery() -> Industry {
         Industry {
             typ: BaseIndustry::Machinery
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TradingCompaniesAndDistributors() -> Industry {
         Industry {
             typ: BaseIndustry::TradingCompaniesAndDistributors
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CommercialServicesAndSupplies() -> Industry {
         Industry {
             typ: BaseIndustry::CommercialServicesAndSupplies
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ProfessionalServices() -> Industry {
         Industry {
             typ: BaseIndustry::ProfessionalServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AirFreightAndLogistics() -> Industry {
         Industry {
             typ: BaseIndustry::AirFreightAndLogistics
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PassengerAirlines() -> Industry {
         Industry {
             typ: BaseIndustry::PassengerAirlines
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MarineTransportation() -> Industry {
         Industry {
             typ: BaseIndustry::MarineTransportation
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GroundTransportation() -> Industry {
         Industry {
             typ: BaseIndustry::GroundTransportation
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TransportationInfrastructure() -> Industry {
         Industry {
             typ: BaseIndustry::TransportationInfrastructure
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AutomobileComponents() -> Industry {
         Industry {
             typ: BaseIndustry::AutomobileComponents
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Automobiles() -> Industry {
         Industry {
             typ: BaseIndustry::Automobiles
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HouseholdDurables() -> Industry {
         Industry {
             typ: BaseIndustry::HouseholdDurables
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LeisureProducts() -> Industry {
         Industry {
             typ: BaseIndustry::LeisureProducts
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TextilesApparelAndLuxuryGoods() -> Industry {
         Industry {
             typ: BaseIndustry::TextilesApparelAndLuxuryGoods
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HotelsRestaurantsAndLeisure() -> Industry {
         Industry {
             typ: BaseIndustry::HotelsRestaurantsAndLeisure
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DiversifiedConsumerServices() -> Industry {
         Industry {
             typ: BaseIndustry::DiversifiedConsumerServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Distributors() -> Industry {
         Industry {
             typ: BaseIndustry::Distributors
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BroadlineRetail() -> Industry {
         Industry {
             typ: BaseIndustry::BroadlineRetail
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SpecialtyRetail() -> Industry {
         Industry {
             typ: BaseIndustry::SpecialtyRetail
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ConsumerStaplesDistributionAndRetail() -> Industry {
         Industry {
             typ: BaseIndustry::ConsumerStaplesDistributionAndRetail
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Beverages() -> Industry {
         Industry {
             typ: BaseIndustry::Beverages
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn FoodProducts() -> Industry {
         Industry {
             typ: BaseIndustry::FoodProducts
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Tobacco() -> Industry {
         Industry {
             typ: BaseIndustry::Tobacco
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HouseholdProducts() -> Industry {
         Industry {
             typ: BaseIndustry::HouseholdProducts
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PersonalCareProducts() -> Industry {
         Industry {
             typ: BaseIndustry::PersonalCareProducts
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HealthCareEquipmentAndSupplies() -> Industry {
         Industry {
             typ: BaseIndustry::HealthCareEquipmentAndSupplies
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HealthCareProvidersAndServices() -> Industry {
         Industry {
             typ: BaseIndustry::HealthCareProvidersAndServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HealthCareTechnology() -> Industry {
         Industry {
             typ: BaseIndustry::HealthCareTechnology
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Biotechnology() -> Industry {
         Industry {
             typ: BaseIndustry::Biotechnology
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Pharmaceuticals() -> Industry {
         Industry {
             typ: BaseIndustry::Pharmaceuticals
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LifeSciencesToolsAndServices() -> Industry {
         Industry {
             typ: BaseIndustry::LifeSciencesToolsAndServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Banks() -> Industry {
         Industry {
             typ: BaseIndustry::Banks
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn FinancialServices() -> Industry {
         Industry {
             typ: BaseIndustry::FinancialServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ConsumerFinance() -> Industry {
         Industry {
             typ: BaseIndustry::ConsumerFinance
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CapitalMarkets() -> Industry {
         Industry {
             typ: BaseIndustry::CapitalMarkets
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MortgageRealEstateInvestmentTrusts() -> Industry {
         Industry {
             typ: BaseIndustry::MortgageRealEstateInvestmentTrusts
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Insurance() -> Industry {
         Industry {
             typ: BaseIndustry::Insurance
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ITServices() -> Industry {
         Industry {
             typ: BaseIndustry::ITServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Software() -> Industry {
         Industry {
             typ: BaseIndustry::Software
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CommunicationsEquipment() -> Industry {
         Industry {
             typ: BaseIndustry::CommunicationsEquipment
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TechnologyHardwareStorageAndPeripherals() -> Industry {
         Industry {
             typ: BaseIndustry::TechnologyHardwareStorageAndPeripherals
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ElectronicEquipmentInstrumentsAndComponents() -> Industry {
         Industry {
             typ: BaseIndustry::ElectronicEquipmentInstrumentsAndComponents
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SemiconductorsAndSemiconductorEquipment() -> Industry {
         Industry {
             typ: BaseIndustry::SemiconductorsAndSemiconductorEquipment
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DiversifiedTelecommunicationServices() -> Industry {
         Industry {
             typ: BaseIndustry::DiversifiedTelecommunicationServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn WirelessTelecommunicationServices() -> Industry {
         Industry {
             typ: BaseIndustry::WirelessTelecommunicationServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Media() -> Industry {
         Industry {
             typ: BaseIndustry::Media
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Entertainment() -> Industry {
         Industry {
             typ: BaseIndustry::Entertainment
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn InteractiveMediaAndServices() -> Industry {
         Industry {
             typ: BaseIndustry::InteractiveMediaAndServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ElectricUtilities() -> Industry {
         Industry {
             typ: BaseIndustry::ElectricUtilities
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GasUtilities() -> Industry {
         Industry {
             typ: BaseIndustry::GasUtilities
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MultiUtilities() -> Industry {
         Industry {
             typ: BaseIndustry::MultiUtilities
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn WaterUtilities() -> Industry {
         Industry {
             typ: BaseIndustry::WaterUtilities
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IndependentPowerAndRenewableElectricityProducers() -> Industry {
         Industry {
             typ: BaseIndustry::IndependentPowerAndRenewableElectricityProducers
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DiversifiedREITs() -> Industry {
         Industry {
             typ: BaseIndustry::DiversifiedREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IndustrialREITs() -> Industry {
         Industry {
             typ: BaseIndustry::IndustrialREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HotelAndResortREITs() -> Industry {
         Industry {
             typ: BaseIndustry::HotelAndResortREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn OfficeREITs() -> Industry {
         Industry {
             typ: BaseIndustry::OfficeREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HealthCareREITs() -> Industry {
         Industry {
             typ: BaseIndustry::HealthCareREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ResidentialREITs() -> Industry {
         Industry {
             typ: BaseIndustry::ResidentialREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RetailREITs() -> Industry {
         Industry {
             typ: BaseIndustry::RetailREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SpecializedREITs() -> Industry {
         Industry {
             typ: BaseIndustry::SpecializedREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RealEstateManagementAndDevelopment() -> Industry {
         Industry {
             typ: BaseIndustry::RealEstateManagementAndDevelopment

--- a/src/sector/industry_group.rs
+++ b/src/sector/industry_group.rs
@@ -1,4 +1,7 @@
+#![allow(non_snake_case)]
+
 use pyo3::prelude::*;
+use pyo3::class::basic::CompareOp;
 use pyo3::types::PyType;
 use strum::IntoEnumIterator;
 use std::str::FromStr;
@@ -31,9 +34,16 @@ impl IndustryGroup {
         Ok(format!("IndustryGroup<{}>", self.typ.to_string()))
     }
 
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.typ == other.typ
-    }
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.typ.to_string() < other.typ.to_string()),
+            CompareOp::Le => Ok(self.typ.to_string() <= other.typ.to_string()),
+            CompareOp::Eq => Ok(self.typ == other.typ),
+            CompareOp::Ne => Ok(self.typ != other.typ),
+            CompareOp::Gt => Ok(self.typ.to_string() > other.typ.to_string()),
+            CompareOp::Ge => Ok(self.typ.to_string() >= other.typ.to_string()),
+        }
+    }    
 
     fn sector(&self) -> Sector {
         Sector {
@@ -59,7 +69,6 @@ impl IndustryGroup {
 
     // Energy
     #[classattr]
-    #[allow(non_snake_case)]
     fn Energy() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::Energy
@@ -68,7 +77,6 @@ impl IndustryGroup {
 
     // Materials
     #[classattr]
-    #[allow(non_snake_case)]
     fn Materials() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::Materials
@@ -77,7 +85,6 @@ impl IndustryGroup {
 
     // Industrials
     #[classattr]
-    #[allow(non_snake_case)]
     fn CapitalGoods() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::CapitalGoods
@@ -85,7 +92,6 @@ impl IndustryGroup {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn CommercialAndProfessionalServices() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::CommercialAndProfessionalServices
@@ -93,7 +99,6 @@ impl IndustryGroup {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn Transportation() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::Transportation
@@ -102,28 +107,24 @@ impl IndustryGroup {
     
     // Consumer Discretionary
     #[classattr]
-    #[allow(non_snake_case)]
     fn AutomobilesAndComponents() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::AutomobilesAndComponents
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ConsumerDurablesAndApparel() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::ConsumerDurablesAndApparel
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ConsumerServices() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::ConsumerServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ConsumerDiscretionaryDistributionAndRetail() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::ConsumerDiscretionaryDistributionAndRetail
@@ -131,21 +132,18 @@ impl IndustryGroup {
     }
     // Consumer Staples
     #[classattr]
-    #[allow(non_snake_case)]
     fn ConsumerStaplesDistributionAndRetail() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::ConsumerStaplesDistributionAndRetail
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn FoodBeverageAndTobacco() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::FoodBeverageAndTobacco
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HouseholdAndPersonalProducts() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::HouseholdAndPersonalProducts
@@ -153,14 +151,12 @@ impl IndustryGroup {
     }
     // Health Care
     #[classattr]
-    #[allow(non_snake_case)]
     fn HealthCareEquipmentAndServices() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::HealthCareEquipmentAndServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PharmaceuticalsBiotechnologyAndLifeSciences() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::PharmaceuticalsBiotechnologyAndLifeSciences
@@ -168,21 +164,18 @@ impl IndustryGroup {
     }
     // Financials
     #[classattr]
-    #[allow(non_snake_case)]
     fn Banks() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::Banks
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn FinancialServices() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::FinancialServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Insurance() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::Insurance
@@ -190,21 +183,18 @@ impl IndustryGroup {
     }
     // Information Technology
     #[classattr]
-    #[allow(non_snake_case)]
     fn SoftwareAndServices() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::SoftwareAndServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TechnologyHardwareAndEquipment() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::TechnologyHardwareAndEquipment
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SemiconductorsAndSemiconductorEquipment() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::SemiconductorsAndSemiconductorEquipment
@@ -212,14 +202,12 @@ impl IndustryGroup {
     }
     // Communication Services
     #[classattr]
-    #[allow(non_snake_case)]
     fn TelecommunicationServices() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::TelecommunicationServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MediaAndEntertainment() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::MediaAndEntertainment
@@ -227,7 +215,6 @@ impl IndustryGroup {
     }
     // Utilities
     #[classattr]
-    #[allow(non_snake_case)]
     fn Utilities() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::Utilities
@@ -235,14 +222,12 @@ impl IndustryGroup {
     }
     // Real Estate
     #[classattr]
-    #[allow(non_snake_case)]
     fn EquityRealEstateInvestmentTrusts() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::EquityRealEstateInvestmentTrusts
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RealEstateManagementAndDevelopment() -> IndustryGroup {
         IndustryGroup {
             typ: BaseIndustryGroup::RealEstateManagementAndDevelopment

--- a/src/sector/sector.rs
+++ b/src/sector/sector.rs
@@ -1,4 +1,7 @@
+#![allow(non_snake_case)]
+
 use pyo3::prelude::*;
+use pyo3::class::basic::CompareOp;
 use pyo3::types::PyType;
 use strum::IntoEnumIterator;
 use std::str::FromStr;
@@ -31,9 +34,16 @@ impl Sector {
         Ok(format!("Sector<{}>", self.typ.to_string()))
     }
 
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.typ == other.typ
-    }
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.typ.to_string() < other.typ.to_string()),
+            CompareOp::Le => Ok(self.typ.to_string() <= other.typ.to_string()),
+            CompareOp::Eq => Ok(self.typ == other.typ),
+            CompareOp::Ne => Ok(self.typ != other.typ),
+            CompareOp::Gt => Ok(self.typ.to_string() > other.typ.to_string()),
+            CompareOp::Ge => Ok(self.typ.to_string() >= other.typ.to_string()),
+        }
+    }    
 
     fn industry_groups(&self) -> Vec<IndustryGroup> {
         self.typ.industry_groups().iter().map(|item| IndustryGroup{typ: item.clone()} ).collect()
@@ -53,7 +63,6 @@ impl Sector {
 
     // Enum values
     #[classattr]
-    #[allow(non_snake_case)]
     fn Energy() -> Sector {
         Sector {
             typ: BaseSector::Energy
@@ -61,7 +70,6 @@ impl Sector {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn Materials() -> Sector {
         Sector {
             typ: BaseSector::Materials
@@ -69,7 +77,6 @@ impl Sector {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn Industrials() -> Sector {
         Sector {
             typ: BaseSector::Industrials
@@ -77,7 +84,6 @@ impl Sector {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn ConsumerDiscretionary() -> Sector {
         Sector {
             typ: BaseSector::ConsumerDiscretionary
@@ -85,7 +91,6 @@ impl Sector {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn ConsumerStaples() -> Sector {
         Sector {
             typ: BaseSector::ConsumerStaples
@@ -93,7 +98,6 @@ impl Sector {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn HealthCare() -> Sector {
         Sector {
             typ: BaseSector::HealthCare
@@ -101,7 +105,6 @@ impl Sector {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn Financials() -> Sector {
         Sector {
             typ: BaseSector::Financials
@@ -109,7 +112,6 @@ impl Sector {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn InformationTechnology() -> Sector {
         Sector {
             typ: BaseSector::InformationTechnology
@@ -117,7 +119,6 @@ impl Sector {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn CommunicationServices() -> Sector {
         Sector {
             typ: BaseSector::CommunicationServices
@@ -125,7 +126,6 @@ impl Sector {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn Utilities() -> Sector {
         Sector {
             typ: BaseSector::Utilities
@@ -133,7 +133,6 @@ impl Sector {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn RealEstate() -> Sector {
         Sector {
             typ: BaseSector::RealEstate

--- a/src/sector/subindustry.rs
+++ b/src/sector/subindustry.rs
@@ -1,4 +1,7 @@
+#![allow(non_snake_case)]
+
 use pyo3::prelude::*;
+use pyo3::class::basic::CompareOp;
 use pyo3::types::PyType;
 use strum::IntoEnumIterator;
 use std::str::FromStr;
@@ -31,9 +34,16 @@ impl SubIndustry {
         Ok(format!("SubIndustry<{}>", self.typ.to_string()))
     }
 
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.typ == other.typ
-    }
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.typ.to_string() < other.typ.to_string()),
+            CompareOp::Le => Ok(self.typ.to_string() <= other.typ.to_string()),
+            CompareOp::Eq => Ok(self.typ == other.typ),
+            CompareOp::Ne => Ok(self.typ != other.typ),
+            CompareOp::Gt => Ok(self.typ.to_string() > other.typ.to_string()),
+            CompareOp::Ge => Ok(self.typ.to_string() >= other.typ.to_string()),
+        }
+    }    
 
     fn industry(&self) -> Industry {
         Industry {
@@ -54,1141 +64,978 @@ impl SubIndustry {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn OilAndGasDrilling() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::OilAndGasDrilling
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn OilAndGasEquipmentAndServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::OilAndGasEquipmentAndServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IntegratedOilAndGas() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::IntegratedOilAndGas
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn OilAndGasExplorationAndProduction() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::OilAndGasExplorationAndProduction
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn OilAndGasRefiningAndMarketing() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::OilAndGasRefiningAndMarketing
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn OilAndGasStorageAndTransportation() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::OilAndGasStorageAndTransportation
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CoalAndConsumeableFuels() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::CoalAndConsumeableFuels
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CommodityChemicals() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::CommodityChemicals
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DiversifiedChemicals() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::DiversifiedChemicals
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn FertilizersAndAgriculturalChemicals() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::FertilizersAndAgriculturalChemicals
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IndustrialGases() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::IndustrialGases
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SpecialtyChemicals() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::SpecialtyChemicals
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ConstructionMaterials() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ConstructionMaterials
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MetalGlassAndPlasticContainers() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::MetalGlassAndPlasticContainers
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PaperAndPlasticPackagingProductsAndMaterials() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::PaperAndPlasticPackagingProductsAndMaterials
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Aluminum() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Aluminum
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DiversifiedMetalsAndMining() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::DiversifiedMetalsAndMining
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Copper() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Copper
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Gold() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Gold
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PreciousMetalsAndMinerals() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::PreciousMetalsAndMinerals
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Silver() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Silver
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Steel() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Steel
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ForestProducts() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ForestProducts
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PaperProducts() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::PaperProducts
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AerospaceAndDefense() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::AerospaceAndDefense
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BuildingProducts() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::BuildingProducts
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ConstructionAndEngineering() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ConstructionAndEngineering
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ElectricalComponentsAndEquipment() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ElectricalComponentsAndEquipment
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HeavyElectricalEquipment() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HeavyElectricalEquipment
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IndustrialConglomerates() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::IndustrialConglomerates
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ConstructionMachineryAndHeavyTransportationEquipment() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ConstructionMachineryAndHeavyTransportationEquipment
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AgriculturalAndFarmMachinery() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::AgriculturalAndFarmMachinery
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IndustrialMachinerySuppliesAndComponents() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::IndustrialMachinerySuppliesAndComponents
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TradingCompaniesAndDistributors() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::TradingCompaniesAndDistributors
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CommercialPrinting() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::CommercialPrinting
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn EnvironmentalAndFacilitiesServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::EnvironmentalAndFacilitiesServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn OfficeServicesAndSupplies() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::OfficeServicesAndSupplies
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DiviersifiedSupportServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::DiviersifiedSupportServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SecurityAndAlarmServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::SecurityAndAlarmServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HumanResourcesAndEmploymentServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HumanResourcesAndEmploymentServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ResearchAndConsultingServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ResearchAndConsultingServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DataProcessingAndOutsourcedServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::DataProcessingAndOutsourcedServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AirFreightAndLogistics() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::AirFreightAndLogistics
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PassengerAirlines() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::PassengerAirlines
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MarineTransportation() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::MarineTransportation
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RailTransportation() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::RailTransportation
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CargoGroundTransportation() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::CargoGroundTransportation
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PassengerGroundTransportation() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::PassengerGroundTransportation
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AirportServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::AirportServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HighwaysAndRailtracks() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HighwaysAndRailtracks
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MarinePortsAndServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::MarinePortsAndServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AutomotivePartsAndEquipment() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::AutomotivePartsAndEquipment
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TiresAndRubber() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::TiresAndRubber
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AutomobileManufacturers() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::AutomobileManufacturers
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MotorcycleManufacturers() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::MotorcycleManufacturers
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ConsumerElectronics() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ConsumerElectronics
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HomeFurnishings() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HomeFurnishings
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Homebuilding() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Homebuilding
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HouseholdAppliances() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HouseholdAppliances
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HousewaresAndSpecialties() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HousewaresAndSpecialties
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LeisureProducts() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::LeisureProducts
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ApparelAccessoriesAndLuxuryGoods() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ApparelAccessoriesAndLuxuryGoods
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Footwear() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Footwear
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Textiles() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Textiles
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CasinosAndGaming() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::CasinosAndGaming
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HotelsResortsAndCruiseLines() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HotelsResortsAndCruiseLines
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LeisureFacilities() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::LeisureFacilities
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Restaurants() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Restaurants
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn EducationServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::EducationServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SpecializedConsumerServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::SpecializedConsumerServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Distributors() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Distributors
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn BroadlineRetail() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::BroadlineRetail
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ApparelRetail() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ApparelRetail
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ComputerAndElectronicsretail() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ComputerAndElectronicsretail
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HomeImprovementRetail() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HomeImprovementRetail
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn OtherSpecialtyRetail() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::OtherSpecialtyRetail
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AutomotiveRetail() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::AutomotiveRetail
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HomefurnishingRetail() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HomefurnishingRetail
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DrugRetail() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::DrugRetail
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn FoodDistributors() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::FoodDistributors
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn FoodRetail() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::FoodRetail
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ConsumerStaplesMerchandiseRetail() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ConsumerStaplesMerchandiseRetail
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Brewers() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Brewers
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DistillersAndVintners() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::DistillersAndVintners
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SoftDrinksAndNonAlcoholicBeverages() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::SoftDrinksAndNonAlcoholicBeverages
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AgriculturalProductsAndServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::AgriculturalProductsAndServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PackagedFoodsAndMeats() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::PackagedFoodsAndMeats
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Tobacco() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Tobacco
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HouseholdProducts() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HouseholdProducts
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PersonalCareProducts() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::PersonalCareProducts
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HealthCareEquipment() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HealthCareEquipment
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HealthCareSupplies() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HealthCareSupplies
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HealthCareDistributors() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HealthCareDistributors
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HealthCareServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HealthCareServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HealthCareFacilities() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HealthCareFacilities
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ManagedHealthCare() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ManagedHealthCare
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HealthCareTechnology() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HealthCareTechnology
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Biotechnology() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Biotechnology
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Pharmaceuticals() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Pharmaceuticals
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LifeSciencesToolsAndServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::LifeSciencesToolsAndServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DiversifiedBanks() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::DiversifiedBanks
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RegionalBanks() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::RegionalBanks
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DiversifiedFinancialServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::DiversifiedFinancialServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MultiSectorHoldings() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::MultiSectorHoldings
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SpecializedFinance() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::SpecializedFinance
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CommercialAndResidentialMortgageFinance() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::CommercialAndResidentialMortgageFinance
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TransactionAndPaymentProcessingServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::TransactionAndPaymentProcessingServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ConsumerFinance() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ConsumerFinance
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AssetManagementAndCustodyBanks() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::AssetManagementAndCustodyBanks
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn InvestmentBankingAndBrokerage() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::InvestmentBankingAndBrokerage
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DiversifiedCapitalMarkets() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::DiversifiedCapitalMarkets
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn FinancialExchangesAndData() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::FinancialExchangesAndData
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MortgageRealEstateInvestmentTrusts() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::MortgageRealEstateInvestmentTrusts
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn InsuranceBrokers() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::InsuranceBrokers
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn LifeAndHealthInsurance() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::LifeAndHealthInsurance
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MultilineInsurance() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::MultilineInsurance
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PropertyAndCasualtyInsurance() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::PropertyAndCasualtyInsurance
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Reinsurance() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Reinsurance
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ITConsultingAndOtherServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ITConsultingAndOtherServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn InternetServicesAndInfrastructure() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::InternetServicesAndInfrastructure
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ApplicationSoftware() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ApplicationSoftware
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SystemsSoftware() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::SystemsSoftware
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CommunicationsEquipment() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::CommunicationsEquipment
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TechnologyHardwareStorageAndPeripherals() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::TechnologyHardwareStorageAndPeripherals
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ElectronicEquipmentAndInstruments() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ElectronicEquipmentAndInstruments
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ElectronicComponents() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ElectronicComponents
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ElectronicManufacturingServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ElectronicManufacturingServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TechnologyDistributors() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::TechnologyDistributors
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SemiconductorMaterialsAndEquipment() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::SemiconductorMaterialsAndEquipment
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Semiconductors() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Semiconductors
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AlternativeCarriers() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::AlternativeCarriers
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IntegratedTelecommunicationServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::IntegratedTelecommunicationServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn WirelessTelecommunicationServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::WirelessTelecommunicationServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Advertising() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Advertising
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Broadcasting() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Broadcasting
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn CableAndSatellite() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::CableAndSatellite
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Publishing() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::Publishing
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MoviesAndEntertainment() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::MoviesAndEntertainment
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn InteractiveHomeEntertainment() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::InteractiveHomeEntertainment
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn InteractiveMediaAndServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::InteractiveMediaAndServices
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ElectricUtilities() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::ElectricUtilities
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GasUtilities() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::GasUtilities
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MultiUtilities() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::MultiUtilities
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn WaterUtilities() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::WaterUtilities
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IndependentPowerProducersAndEnergyTraders() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::IndependentPowerProducersAndEnergyTraders
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RenewableElectricity() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::RenewableElectricity
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DiversifiedREITs() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::DiversifiedREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn IndustrialREITs() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::IndustrialREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HotelAndResortREITs() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HotelAndResortREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn OfficeREITs() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::OfficeREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn HealthCareREITs() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::HealthCareREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MultiFamilyResidentialREITs() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::MultiFamilyResidentialREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SingleFamilyResidentialREITs() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::SingleFamilyResidentialREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RetailREITs() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::RetailREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn OtherSpecializedREITs() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::OtherSpecializedREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn SelfStorageREITs() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::SelfStorageREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TelecomTowerREITs() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::TelecomTowerREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn TimberREITs() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::TimberREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DataCenterREITs() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::DataCenterREITs
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DiversifiedRealEstateActivities() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::DiversifiedRealEstateActivities
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RealEstateOperatingCompanies() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::RealEstateOperatingCompanies
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RealEstateDevelopment() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::RealEstateDevelopment
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn RealEstateServices() -> SubIndustry {
         SubIndustry {
             typ: BaseSubIndustry::RealEstateServices

--- a/src/security/bond.rs
+++ b/src/security/bond.rs
@@ -1,4 +1,7 @@
+#![allow(non_snake_case)]
+
 use pyo3::prelude::*;
+use pyo3::class::basic::CompareOp;
 use pyo3::types::PyType;
 use strum::IntoEnumIterator;
 use std::str::FromStr;
@@ -29,8 +32,15 @@ impl BondType {
         Ok(format!("BondType<{}>", self.typ.to_string()))
     }
     
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.typ == other.typ
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.typ.to_string() < other.typ.to_string()),
+            CompareOp::Le => Ok(self.typ.to_string() <= other.typ.to_string()),
+            CompareOp::Eq => Ok(self.typ == other.typ),
+            CompareOp::Ne => Ok(self.typ != other.typ),
+            CompareOp::Gt => Ok(self.typ.to_string() > other.typ.to_string()),
+            CompareOp::Ge => Ok(self.typ.to_string() >= other.typ.to_string()),
+        }
     }
     
     #[classmethod]
@@ -46,21 +56,18 @@ impl BondType {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn Corporate() -> BondType {
         BondType {
             typ: BaseBondType::Corporate
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Government() -> BondType {
         BondType {
             typ: BaseBondType::Government
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Municipal() -> BondType {
         BondType {
             typ: BaseBondType::Municipal

--- a/src/security/commodity.rs
+++ b/src/security/commodity.rs
@@ -1,4 +1,7 @@
+#![allow(non_snake_case)]
+
 use pyo3::prelude::*;
+use pyo3::class::basic::CompareOp;
 use pyo3::types::PyType;
 use strum::IntoEnumIterator;
 use std::str::FromStr;
@@ -28,10 +31,17 @@ impl CommodityType {
     fn __repr__(&self) -> PyResult<String>   {
         Ok(format!("CommodityType<{}>", self.typ.to_string()))
     }
-    
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.typ == other.typ
-    }
+
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.typ.to_string() < other.typ.to_string()),
+            CompareOp::Le => Ok(self.typ.to_string() <= other.typ.to_string()),
+            CompareOp::Eq => Ok(self.typ == other.typ),
+            CompareOp::Ne => Ok(self.typ != other.typ),
+            CompareOp::Gt => Ok(self.typ.to_string() > other.typ.to_string()),
+            CompareOp::Ge => Ok(self.typ.to_string() >= other.typ.to_string()),
+        }
+    }    
     
     #[classmethod]
     fn __len__(_cls: &PyType) -> PyResult<usize> {
@@ -46,21 +56,18 @@ impl CommodityType {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn Energy() -> CommodityType {
         CommodityType {
             typ: BaseCommodityType::Energy
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Metals() -> CommodityType {
         CommodityType {
             typ: BaseCommodityType::Metals
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Agriculture() -> CommodityType {
         CommodityType {
             typ: BaseCommodityType::Agriculture

--- a/src/security/equity.rs
+++ b/src/security/equity.rs
@@ -1,4 +1,7 @@
+#![allow(non_snake_case)]
+
 use pyo3::prelude::*;
+use pyo3::class::basic::CompareOp;
 use pyo3::types::PyType;
 use strum::IntoEnumIterator;
 use std::str::FromStr;
@@ -30,8 +33,15 @@ impl EquityType {
         Ok(format!("EquityType<{}>", self.typ.to_string()))
     }
     
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.typ == other.typ
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.typ.to_string() < other.typ.to_string()),
+            CompareOp::Le => Ok(self.typ.to_string() <= other.typ.to_string()),
+            CompareOp::Eq => Ok(self.typ == other.typ),
+            CompareOp::Ne => Ok(self.typ != other.typ),
+            CompareOp::Gt => Ok(self.typ.to_string() > other.typ.to_string()),
+            CompareOp::Ge => Ok(self.typ.to_string() >= other.typ.to_string()),
+        }
     }
     
     #[classmethod]
@@ -47,35 +57,30 @@ impl EquityType {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn Shares() -> EquityType {
         EquityType {
             typ: BaseEquityType::Shares
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PreferredShares() -> EquityType {
         EquityType {
             typ: BaseEquityType::PreferredShares
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ConvertibleShares() -> EquityType {
         EquityType {
             typ: BaseEquityType::ConvertibleShares
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PreferredConvertibleShares() -> EquityType {
         EquityType {
             typ: BaseEquityType::PreferredConvertibleShares
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn DepositoryReceipt() -> EquityType {
         EquityType {
             typ: BaseEquityType::DepositoryReceipt

--- a/src/security/fund.rs
+++ b/src/security/fund.rs
@@ -1,4 +1,7 @@
+#![allow(non_snake_case)]
+
 use pyo3::prelude::*;
+use pyo3::class::basic::CompareOp;
 use pyo3::types::PyType;
 use strum::IntoEnumIterator;
 use std::str::FromStr;
@@ -30,8 +33,15 @@ impl FundType {
         Ok(format!("FundType<{}>", self.typ.to_string()))
     }
     
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.typ == other.typ
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.typ.to_string() < other.typ.to_string()),
+            CompareOp::Le => Ok(self.typ.to_string() <= other.typ.to_string()),
+            CompareOp::Eq => Ok(self.typ == other.typ),
+            CompareOp::Ne => Ok(self.typ != other.typ),
+            CompareOp::Gt => Ok(self.typ.to_string() > other.typ.to_string()),
+            CompareOp::Ge => Ok(self.typ.to_string() >= other.typ.to_string()),
+        }
     }
     
     #[classmethod]
@@ -47,21 +57,18 @@ impl FundType {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn ETF() -> FundType {
         FundType {
             typ: BaseFundType::ETF
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn MutualFund() -> FundType {
         FundType {
             typ: BaseFundType::MutualFund
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn REIT() -> FundType {
         FundType {
             typ: BaseFundType::REIT
@@ -93,9 +100,16 @@ impl FundSubType {
         Ok(format!("FundSubType<{}>", self.typ.to_string()))
     }
     
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.typ == other.typ
-    }
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.typ.to_string() < other.typ.to_string()),
+            CompareOp::Le => Ok(self.typ.to_string() <= other.typ.to_string()),
+            CompareOp::Eq => Ok(self.typ == other.typ),
+            CompareOp::Ne => Ok(self.typ != other.typ),
+            CompareOp::Gt => Ok(self.typ.to_string() > other.typ.to_string()),
+            CompareOp::Ge => Ok(self.typ.to_string() >= other.typ.to_string()),
+        }
+    }    
     
     #[classmethod]
     fn __len__(_cls: &PyType) -> PyResult<usize> {
@@ -110,28 +124,24 @@ impl FundSubType {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn Index() -> FundSubType {
         FundSubType {
             typ: BaseFundSubType::Index
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Sector() -> FundSubType {
         FundSubType {
             typ: BaseFundSubType::Sector
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Active() -> FundSubType {
         FundSubType {
             typ: BaseFundSubType::Active
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Passive() -> FundSubType {
         FundSubType {
             typ: BaseFundSubType::Passive
@@ -163,8 +173,15 @@ impl MutualFundEndedness {
         Ok(format!("MutualFundEndedness<{}>", self.typ.to_string()))
     }
     
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.typ == other.typ
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.typ.to_string() < other.typ.to_string()),
+            CompareOp::Le => Ok(self.typ.to_string() <= other.typ.to_string()),
+            CompareOp::Eq => Ok(self.typ == other.typ),
+            CompareOp::Ne => Ok(self.typ != other.typ),
+            CompareOp::Gt => Ok(self.typ.to_string() > other.typ.to_string()),
+            CompareOp::Ge => Ok(self.typ.to_string() >= other.typ.to_string()),
+        }
     }
     
     #[classmethod]
@@ -180,14 +197,12 @@ impl MutualFundEndedness {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn Open() -> MutualFundEndedness {
         MutualFundEndedness {
             typ: BaseMutualFundEndedness::Open
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Close() -> MutualFundEndedness {
         MutualFundEndedness {
             typ: BaseMutualFundEndedness::Close

--- a/src/security/option.rs
+++ b/src/security/option.rs
@@ -1,4 +1,7 @@
+#![allow(non_snake_case)]
+
 use pyo3::prelude::*;
+use pyo3::class::basic::CompareOp;
 use pyo3::types::PyType;
 use strum::IntoEnumIterator;
 use std::str::FromStr;
@@ -30,9 +33,16 @@ impl OptionType {
         Ok(format!("OptionType<{}>", self.typ.to_string()))
     }
     
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.typ == other.typ
-    }
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.typ.to_string() < other.typ.to_string()),
+            CompareOp::Le => Ok(self.typ.to_string() <= other.typ.to_string()),
+            CompareOp::Eq => Ok(self.typ == other.typ),
+            CompareOp::Ne => Ok(self.typ != other.typ),
+            CompareOp::Gt => Ok(self.typ.to_string() > other.typ.to_string()),
+            CompareOp::Ge => Ok(self.typ.to_string() >= other.typ.to_string()),
+        }
+    }    
     
     #[classmethod]
     fn __len__(_cls: &PyType) -> PyResult<usize> {
@@ -47,14 +57,12 @@ impl OptionType {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn Call() -> OptionType {
         OptionType {
             typ: BaseOptionType::Call
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Put() -> OptionType {
         OptionType {
             typ: BaseOptionType::Put
@@ -86,8 +94,15 @@ impl OptionExerciseType {
         Ok(format!("OptionExerciseType<{}>", self.typ.to_string()))
     }
     
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.typ == other.typ
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.typ.to_string() < other.typ.to_string()),
+            CompareOp::Le => Ok(self.typ.to_string() <= other.typ.to_string()),
+            CompareOp::Eq => Ok(self.typ == other.typ),
+            CompareOp::Ne => Ok(self.typ != other.typ),
+            CompareOp::Gt => Ok(self.typ.to_string() > other.typ.to_string()),
+            CompareOp::Ge => Ok(self.typ.to_string() >= other.typ.to_string()),
+        }
     }
     
     #[classmethod]
@@ -103,21 +118,18 @@ impl OptionExerciseType {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn American() -> OptionExerciseType {
         OptionExerciseType {
             typ: BaseOptionExerciseType::American
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn European() -> OptionExerciseType {
         OptionExerciseType {
             typ: BaseOptionExerciseType::European
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Bermudan() -> OptionExerciseType {
         OptionExerciseType {
             typ: BaseOptionExerciseType::Bermudan

--- a/src/security/security.rs
+++ b/src/security/security.rs
@@ -1,4 +1,7 @@
+#![allow(non_snake_case)]
+
 use pyo3::prelude::*;
+use pyo3::class::basic::CompareOp;
 use pyo3::types::PyType;
 use strum::IntoEnumIterator;
 use std::str::FromStr;
@@ -29,9 +32,16 @@ impl SecurityType {
         Ok(format!("SecurityType<{}>", self.typ.to_string()))
     }
     
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.typ == other.typ
-    }
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.typ.to_string() < other.typ.to_string()),
+            CompareOp::Le => Ok(self.typ.to_string() <= other.typ.to_string()),
+            CompareOp::Eq => Ok(self.typ == other.typ),
+            CompareOp::Ne => Ok(self.typ != other.typ),
+            CompareOp::Gt => Ok(self.typ.to_string() > other.typ.to_string()),
+            CompareOp::Ge => Ok(self.typ.to_string() >= other.typ.to_string()),
+        }
+    }    
     
     #[classmethod]
     fn __len__(_cls: &PyType) -> PyResult<usize> {
@@ -47,84 +57,72 @@ impl SecurityType {
 
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn Equity() -> SecurityType {
         SecurityType {
             typ: BaseSecurityType::Equity
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Option() -> SecurityType {
         SecurityType {
             typ: BaseSecurityType::Option
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Bond() -> SecurityType {
         SecurityType {
             typ: BaseSecurityType::Bond
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Forward() -> SecurityType {
         SecurityType {
             typ: BaseSecurityType::Forward
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Future() -> SecurityType {
         SecurityType {
             typ: BaseSecurityType::Future
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn PerpetualFuture() -> SecurityType {
         SecurityType {
             typ: BaseSecurityType::PerpetualFuture
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Spread() -> SecurityType {
         SecurityType {
             typ: BaseSecurityType::Spread
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Fund() -> SecurityType {
         SecurityType {
             typ: BaseSecurityType::Fund
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Commodity() -> SecurityType {
         SecurityType {
             typ: BaseSecurityType::Commodity
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Currency() -> SecurityType {
         SecurityType {
             typ: BaseSecurityType::Currency
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Pair() -> SecurityType {
         SecurityType {
             typ: BaseSecurityType::Pair
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Index() -> SecurityType {
         SecurityType {
             typ: BaseSecurityType::Index

--- a/src/trading/mod.rs
+++ b/src/trading/mod.rs
@@ -1,22 +1,12 @@
+#![allow(non_snake_case)]
+
 use pyo3::prelude::*;
+use pyo3::class::basic::CompareOp;
 use pyo3::types::PyType;
 use strum::IntoEnumIterator;
 use std::str::FromStr;
 
 use finance_enums::{OrderType as BaseOrderType, Side as BaseSide, TimeInForce as BaseTimeInForce, OrderFlag as BaseOrderFlag};
-
-// pub enum TimeInForce {
-//     Day,
-//     GTC,
-// }
-
-// pub enum OrderFlag {
-//     None,
-//     FillOrKill,
-//     ImmediateOrCancel,
-//     AllOrNone,
-// }
-
 
 
 #[pyclass]
@@ -42,9 +32,17 @@ impl OrderType {
     fn __repr__(&self) -> PyResult<String>   {
         Ok(format!("OrderType<{}>", self.typ.to_string()))
     }
-    
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.typ == other.typ
+
+
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.typ.to_string() < other.typ.to_string()),
+            CompareOp::Le => Ok(self.typ.to_string() <= other.typ.to_string()),
+            CompareOp::Eq => Ok(self.typ == other.typ),
+            CompareOp::Ne => Ok(self.typ != other.typ),
+            CompareOp::Gt => Ok(self.typ.to_string() > other.typ.to_string()),
+            CompareOp::Ge => Ok(self.typ.to_string() >= other.typ.to_string()),
+        }
     }
     
     #[classmethod]
@@ -60,21 +58,18 @@ impl OrderType {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn Market() -> OrderType {
         OrderType {
             typ: BaseOrderType::Market
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Limit() -> OrderType {
         OrderType {
             typ: BaseOrderType::Limit
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Stop() -> OrderType {
         OrderType {
             typ: BaseOrderType::Stop
@@ -107,10 +102,17 @@ impl Side {
         Ok(format!("Side<{}>", self.typ.to_string()))
     }
     
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.typ == other.typ
-    }
-    
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.typ.to_string() < other.typ.to_string()),
+            CompareOp::Le => Ok(self.typ.to_string() <= other.typ.to_string()),
+            CompareOp::Eq => Ok(self.typ == other.typ),
+            CompareOp::Ne => Ok(self.typ != other.typ),
+            CompareOp::Gt => Ok(self.typ.to_string() > other.typ.to_string()),
+            CompareOp::Ge => Ok(self.typ.to_string() >= other.typ.to_string()),
+        }
+    }    
+
     #[classmethod]
     fn __len__(_cls: &PyType) -> PyResult<usize> {
         Ok(BaseSide::iter().count())
@@ -124,14 +126,12 @@ impl Side {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn Buy() -> Side {
         Side {
             typ: BaseSide::Buy
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn Sell() -> Side {
         Side {
             typ: BaseSide::Sell
@@ -164,9 +164,16 @@ impl TimeInForce {
         Ok(format!("TimeInForce<{}>", self.typ.to_string()))
     }
     
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.typ == other.typ
-    }
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.typ.to_string() < other.typ.to_string()),
+            CompareOp::Le => Ok(self.typ.to_string() <= other.typ.to_string()),
+            CompareOp::Eq => Ok(self.typ == other.typ),
+            CompareOp::Ne => Ok(self.typ != other.typ),
+            CompareOp::Gt => Ok(self.typ.to_string() > other.typ.to_string()),
+            CompareOp::Ge => Ok(self.typ.to_string() >= other.typ.to_string()),
+        }
+    }    
     
     #[classmethod]
     fn __len__(_cls: &PyType) -> PyResult<usize> {
@@ -181,14 +188,12 @@ impl TimeInForce {
     }
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn Day() -> TimeInForce {
         TimeInForce {
             typ: BaseTimeInForce::Day
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn GTC() -> TimeInForce {
         TimeInForce {
             typ: BaseTimeInForce::GTC
@@ -222,8 +227,15 @@ impl OrderFlag {
         Ok(format!("OrderFlag<{}>", self.typ.to_string()))
     }
     
-    fn __eq__(&self, other: &Self) -> bool   {
-        self.typ == other.typ
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Lt => Ok(self.typ.to_string() < other.typ.to_string()),
+            CompareOp::Le => Ok(self.typ.to_string() <= other.typ.to_string()),
+            CompareOp::Eq => Ok(self.typ == other.typ),
+            CompareOp::Ne => Ok(self.typ != other.typ),
+            CompareOp::Gt => Ok(self.typ.to_string() > other.typ.to_string()),
+            CompareOp::Ge => Ok(self.typ.to_string() >= other.typ.to_string()),
+        }
     }
     
     #[classmethod]
@@ -240,28 +252,24 @@ impl OrderFlag {
 
 
     #[classattr]
-    #[allow(non_snake_case)]
     fn None() -> OrderFlag {
         OrderFlag {
             typ: BaseOrderFlag::None
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn FillOrKill() -> OrderFlag {
         OrderFlag {
             typ: BaseOrderFlag::FillOrKill
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn ImmediateOrCancel() -> OrderFlag {
         OrderFlag {
             typ: BaseOrderFlag::ImmediateOrCancel
         }
     }
     #[classattr]
-    #[allow(non_snake_case)]
     fn AllOrNone() -> OrderFlag {
         OrderFlag {
             typ: BaseOrderFlag::AllOrNone


### PR DESCRIPTION
In our previous PR, we implement `__eq__` for all python classes, but this was an oversight, `__richcmp__` shouldve been implemented. This PR fixes that.

Note that `==` and `!=` use the fast path of `PartialEq` on the Enum, whereas the other comparators use a slow string path. This should be considered an acceptable tradeoff as these enums don't really have a natural ordering other than alphabetical, and `==` is expected to be used vastly more often than any other comparator. 

This PR also adds support for `GBX`, `EUX` and `USX`, which are the penny equivalents of GBP, EUR, and USD. 